### PR TITLE
Flatten src folder using build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,25 @@
 P2P QUIC with seamless connection migration.
 
 This project uses [a modified quic-go](https://github.com/kota-yata/quic-go).
+
+## Building individual binaries
+
+All source files now live in `src/` and use build tags. Build each component with:
+
+```bash
+# Build client
+go build -tags client -o bin/client ./src
+
+# Build server
+go build -tags server -o bin/server ./src
+
+# Build intermediate server
+go build -tags intermediate -o bin/intermediate-server ./src
+```
+
+You can also run them directly with `go run` using the corresponding tag. For example:
+
+```bash
+go run -tags client ./src
+```
+

--- a/src/client.go
+++ b/src/client.go
@@ -1,3 +1,6 @@
+//go:build client
+// +build client
+
 package main
 
 import (

--- a/src/intermediate_server.go
+++ b/src/intermediate_server.go
@@ -1,3 +1,6 @@
+//go:build intermediate
+// +build intermediate
+
 package main
 
 import (

--- a/src/server.go
+++ b/src/server.go
@@ -1,3 +1,6 @@
+//go:build server
+// +build server
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- move the three main packages into `src/` as separate files
- add build tags so each binary can be built from the single folder
- document how to build or run using the tags

## Testing
- `go build -tags client ./src` *(fails: replacement directory ../quic-go does not exist)*
- `go build -tags server ./src` *(fails: replacement directory ../quic-go does not exist)*
- `go build -tags intermediate ./src` *(fails: replacement directory ../quic-go does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6867b3299d3c8322b694427f8dd03e49